### PR TITLE
feat: register templates import module

### DIFF
--- a/src/importModule.ts
+++ b/src/importModule.ts
@@ -1,0 +1,13 @@
+import { ImportModule, FileSystemItem, ImportContext } from "api/types";
+
+const templatesImportModule: ImportModule = {
+    format: "templates",
+    description: "Templates",
+    isNoteArchive: false,
+    sources: [FileSystemItem.File, FileSystemItem.Directory],
+    async onExec(_context: ImportContext): Promise<void> {
+        // TODO: implement template import logic
+    },
+};
+
+export default templatesImportModule;

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { PromiseGroup } from "./utils/promises";
 import { PluginSettingsRegistry, DefaultNoteTemplateIdSetting, DefaultTodoTemplateIdSetting, DefaultTemplatesConfigSetting } from "./settings";
 import { LocaleGlobalSetting, DateFormatGlobalSetting, TimeFormatGlobalSetting, ProfileDirGlobalSetting } from "./settings/global";
 import { DefaultTemplatesConfig } from "./settings/defaultTemplatesConfig";
+import templatesImportModule from "./importModule";
 
 const DOCUMENTATION_URL = "https://github.com/joplin/plugin-templates#readme";
 
@@ -40,6 +41,8 @@ joplin.plugins.register({
         const dateAndTimeUtils = new DateAndTimeUtils(userLocale, userDateFormat, userTimeFormat);
         const logger = new Logger(profileDir);
         const parser = new Parser(dateAndTimeUtils, dialogViewHandle, logger);
+
+        await joplin.interop.registerImportModule(templatesImportModule);
 
 
         // Asynchronously load legacy templates


### PR DESCRIPTION
## Summary
- register import module during plugin startup
- add stub templates import module for future implementation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cabc242a4832995340adbc50c8b49