### PR TITLE
refactor: camelCase constant names

### DIFF
--- a/scripts/announceRelease.js
+++ b/scripts/announceRelease.js
@@ -3,18 +3,18 @@ require("dotenv").config()
 const fs = require("fs-extra");
 const axios = require("axios").default;
 
-const PACKAGE_JSON_PATH = "./package.json";
-const CHANGELOG_PATH = "./CHANGELOG.md";
+const packageJsonPath = "./package.json";
+const changelogPath = "./CHANGELOG.md";
 
-const GITHUB_ACCESS_TOKEN = process.env.GITHUB_ACCESS_TOKEN;
-const DISCOURSE_API_KEY = process.env.DISCOURSE_API_KEY;
-const DISCOURSE_URL = "https://discourse.joplinapp.org";
-const TEMPLATE_PLUGIN_TOPIC_ID = 17470;
-const PLUGIN_REPO = "https://www.github.com/joplin/plugin-templates";
+const githubAccessToken = process.env.GITHUB_ACCESS_TOKEN;
+const discourseApiKey = process.env.DISCOURSE_API_KEY;
+const discourseUrl = "https://discourse.joplinapp.org";
+const templatePluginTopicId = 17470;
+const pluginRepo = "https://www.github.com/joplin/plugin-templates";
 
 const getLatestRelease = async () => {
-    const version = JSON.parse(await fs.readFile(PACKAGE_JSON_PATH, "utf-8")).version;
-    const changelog = await fs.readFile(CHANGELOG_PATH, "utf-8");
+    const version = JSON.parse(await fs.readFile(packageJsonPath, "utf-8")).version;
+    const changelog = await fs.readFile(changelogPath, "utf-8");
 
     const releaseHeadings = changelog.match(/###? \[.*/gm);
 
@@ -32,18 +32,18 @@ const getLatestRelease = async () => {
 }
 
 const createGithubRelease = async (release) => {
-    const tag_name = `v${release.version}`;
+    const tagName = `v${release.version}`;
 
     const response = await axios.post(
         "https://api.github.com/repos/joplin/plugin-templates/releases",
         {
-            tag_name: tag_name,
-            name: tag_name,
+            tag_name: tagName,
+            name: tagName,
             body: release.changelog
         },
         {
             headers: {
-                "Authorization": `Token ${GITHUB_ACCESS_TOKEN}`
+                "Authorization": `Token ${githubAccessToken}`
             }
         });
 
@@ -51,23 +51,23 @@ const createGithubRelease = async (release) => {
 }
 
 const createJoplinReleasePost = async (release) => {
-    const postContent = `## Release v${release.version} :rocket:\n${release.changelog}\n\n> For reporting bugs/feature-requests or to know more about the plugin visit the [GitHub Repo](${PLUGIN_REPO}).`;
+    const postContent = `## Release v${release.version} :rocket:\n${release.changelog}\n\n> For reporting bugs/feature-requests or to know more about the plugin visit the [GitHub Repo](${pluginRepo}).`;
 
     const response = await axios.post(
-        `${DISCOURSE_URL}/posts.json`,
+        `${discourseUrl}/posts.json`,
         {
-            topic_id: `${TEMPLATE_PLUGIN_TOPIC_ID}`,
+            topic_id: `${templatePluginTopicId}`,
             raw: postContent
         },
         {
             headers: {
-                "Api-Key": DISCOURSE_API_KEY,
+                "Api-Key": discourseApiKey,
                 "Api-Username": "nishantwrp"
             }
         }
     );
 
-    return `${DISCOURSE_URL}/t/${TEMPLATE_PLUGIN_TOPIC_ID}/${response.data.post_number}`;
+    return `${discourseUrl}/t/${templatePluginTopicId}/${response.data.post_number}`;
 }
 
 const announceRelease = async () => {

--- a/src/helpers/datetime.ts
+++ b/src/helpers/datetime.ts
@@ -2,60 +2,60 @@ import { HandlebarsHelper, HelperConstructorBlock } from "./helper";
 import { AttributeValueType, AttributeDefinition, AttributeParser } from "./utils/attributes";
 import * as moment from "moment";
 
-const FORMAT = "format";
-const SET_DATE = "set_date";
-const SET_TIME = "set_time";
-const DELTA_YEARS = "delta_years";
-const DELTA_MONTHS = "delta_months";
-const DELTA_DAYS = "delta_days";
-const DELTA_HOURS = "delta_hours";
-const DELTA_MINUTES = "delta_minutes";
-const DELTA_SECONDS = "delta_seconds";
+const format = "format";
+const setDate = "set_date";
+const setTime = "set_time";
+const deltaYears = "delta_years";
+const deltaMonths = "delta_months";
+const deltaDays = "delta_days";
+const deltaHours = "delta_hours";
+const deltaMinutes = "delta_minutes";
+const deltaSeconds = "delta_seconds";
 
 export const datetimeHelper: HelperConstructorBlock = (ctx) => {
     const schema: AttributeDefinition[] = [
         {
-            name: FORMAT,
+            name: format,
             valueType: AttributeValueType.String,
             defaultValue: ctx.dateAndTimeUtils.getDateTimeFormat()
         },
         {
-            name: SET_DATE,
+            name: setDate,
             valueType: AttributeValueType.String,
             defaultValue: ""
         },
         {
-            name: SET_TIME,
+            name: setTime,
             valueType: AttributeValueType.String,
             defaultValue: ""
         },
         {
-            name: DELTA_YEARS,
+            name: deltaYears,
             valueType: AttributeValueType.Number,
             defaultValue: 0
         },
         {
-            name: DELTA_MONTHS,
+            name: deltaMonths,
             valueType: AttributeValueType.Number,
             defaultValue: 0
         },
         {
-            name: DELTA_DAYS,
+            name: deltaDays,
             valueType: AttributeValueType.Number,
             defaultValue: 0
         },
         {
-            name: DELTA_HOURS,
+            name: deltaHours,
             valueType: AttributeValueType.Number,
             defaultValue: 0
         },
         {
-            name: DELTA_MINUTES,
+            name: deltaMinutes,
             valueType: AttributeValueType.Number,
             defaultValue: 0
         },
         {
-            name: DELTA_SECONDS,
+            name: deltaSeconds,
             valueType: AttributeValueType.Number,
             defaultValue: 0
         }
@@ -67,28 +67,28 @@ export const datetimeHelper: HelperConstructorBlock = (ctx) => {
 
         const now = moment(new Date().getTime());
 
-        if (attrs[SET_DATE]) {
-            const parsedDate = ctx.dateAndTimeUtils.parseDate(attrs[SET_DATE] as string, ctx.dateAndTimeUtils.getDateFormat());
+        if (attrs[setDate]) {
+            const parsedDate = ctx.dateAndTimeUtils.parseDate(attrs[setDate] as string, ctx.dateAndTimeUtils.getDateFormat());
             now.set("date", parsedDate.date);
             now.set("month", parsedDate.month);
             now.set("year", parsedDate.year);
         }
 
-        if (attrs[SET_TIME]) {
-            const parsedTime = ctx.dateAndTimeUtils.parseTime(attrs[SET_TIME] as string, ctx.dateAndTimeUtils.getTimeFormat());
+        if (attrs[setTime]) {
+            const parsedTime = ctx.dateAndTimeUtils.parseTime(attrs[setTime] as string, ctx.dateAndTimeUtils.getTimeFormat());
             now.set("hours", parsedTime.hours);
             now.set("minutes", parsedTime.minutes);
             now.set("seconds", parsedTime.seconds);
             now.set("milliseconds", 0);
         }
 
-        now.add(attrs[DELTA_YEARS] as number, "years");
-        now.add(attrs[DELTA_MONTHS] as number, "months");
-        now.add(attrs[DELTA_DAYS] as number, "days");
-        now.add(attrs[DELTA_HOURS] as number, "hours");
-        now.add(attrs[DELTA_MINUTES] as number, "minutes");
-        now.add(attrs[DELTA_SECONDS] as number, "seconds");
+        now.add(attrs[deltaYears] as number, "years");
+        now.add(attrs[deltaMonths] as number, "months");
+        now.add(attrs[deltaDays] as number, "days");
+        now.add(attrs[deltaHours] as number, "hours");
+        now.add(attrs[deltaMinutes] as number, "minutes");
+        now.add(attrs[deltaSeconds] as number, "seconds");
 
-        return ctx.dateAndTimeUtils.formatMsToLocal(now.toDate().getTime(), attrs[FORMAT] as string);
+        return ctx.dateAndTimeUtils.formatMsToLocal(now.toDate().getTime(), attrs[format] as string);
     });
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import { LocaleGlobalSetting, DateFormatGlobalSetting, TimeFormatGlobalSetting, 
 import { DefaultTemplatesConfig } from "./settings/defaultTemplatesConfig";
 import templatesImportModule from "./importModule";
 
-const DOCUMENTATION_URL = "https://github.com/joplin/plugin-templates#readme";
+const documentationUrl = "https://github.com/joplin/plugin-templates#readme";
 
 joplin.plugins.register({
     onStart: async function() {
@@ -248,7 +248,7 @@ joplin.plugins.register({
             name: "showPluginDocumentation",
             label: "Help",
             execute: async () => {
-                open(DOCUMENTATION_URL);
+                open(documentationUrl);
             }
         }));
 

--- a/src/legacyTemplates.ts
+++ b/src/legacyTemplates.ts
@@ -3,7 +3,7 @@ import { DateAndTimeUtils } from "./utils/dateAndTime";
 import { createFolder } from "./utils/folders";
 import { applyTagToNote, getAnyTagWithTitle } from "./utils/tags";
 
-const README_BODY = (
+const readmeBody = (
     `**✅ Legacy Templates successfully imported!**
 
  Quick tips for the Templates Plugin:
@@ -54,6 +54,6 @@ export const loadLegacyTemplates = async (dateAndTimeUtils: DateAndTimeUtils, pr
     }
 
     if (folderId) {
-        await joplin.data.post(["notes"], null, { title: "README", body: README_BODY, parent_id: folderId });
+        await joplin.data.post(["notes"], null, { title: "README", body: readmeBody, parent_id: folderId });
     }
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -31,16 +31,16 @@ interface NoteMetadata {
     todo_due: number | null;
 }
 
-const NOTE_TITLE_VARIABLE_NAME = "template_title";
-const NOTE_TAGS_VARIABLE_NAME = "template_tags";
-const NOTE_FOLDER_VARIABLE_NAME = "template_notebook";
-const TODO_DUE_VARIABLE_NAME = "template_todo_alarm";
+const noteTitleVariableName = "template_title";
+const noteTagsVariableName = "template_tags";
+const noteFolderVariableName = "template_notebook";
+const todoDueVariableName = "template_todo_alarm";
 
 export class Parser {
     private utils: DateAndTimeUtils;
     private dialog: string;
     private logger: Logger;
-    private specialVariableNames = [NOTE_TITLE_VARIABLE_NAME, NOTE_TAGS_VARIABLE_NAME, NOTE_FOLDER_VARIABLE_NAME, TODO_DUE_VARIABLE_NAME];
+    private specialVariableNames = [noteTitleVariableName, noteTagsVariableName, noteFolderVariableName, todoDueVariableName];
 
     constructor(dateAndTimeUtils: DateAndTimeUtils, dialogViewHandle: string, logger: Logger) {
         this.utils = dateAndTimeUtils;
@@ -145,16 +145,16 @@ export class Parser {
             todo_due: null,
         };
 
-        if (NOTE_TITLE_VARIABLE_NAME in parsedSpecialVariables) {
-            meta.title = parsedSpecialVariables[NOTE_TITLE_VARIABLE_NAME];
+        if (noteTitleVariableName in parsedSpecialVariables) {
+            meta.title = parsedSpecialVariables[noteTitleVariableName];
         }
 
-        if (NOTE_TAGS_VARIABLE_NAME in parsedSpecialVariables) {
-            meta.tags = parsedSpecialVariables[NOTE_TAGS_VARIABLE_NAME].split(",").map(t => t.trim()).filter(t => t !== "");
+        if (noteTagsVariableName in parsedSpecialVariables) {
+            meta.tags = parsedSpecialVariables[noteTagsVariableName].split(",").map(t => t.trim()).filter(t => t !== "");
         }
 
-        if (NOTE_FOLDER_VARIABLE_NAME in parsedSpecialVariables) {
-            const folderId = parsedSpecialVariables[NOTE_FOLDER_VARIABLE_NAME].trim();
+        if (noteFolderVariableName in parsedSpecialVariables) {
+            const folderId = parsedSpecialVariables[noteFolderVariableName].trim();
             if (await doesFolderExist(folderId)) {
                 meta.folder = folderId;
             } else {
@@ -162,8 +162,8 @@ export class Parser {
             }
         }
 
-        if (TODO_DUE_VARIABLE_NAME in parsedSpecialVariables) {
-            const rawTodoDue = parsedSpecialVariables[TODO_DUE_VARIABLE_NAME].trim()
+        if (todoDueVariableName in parsedSpecialVariables) {
+            const rawTodoDue = parsedSpecialVariables[todoDueVariableName].trim()
             meta.todo_due = this.utils.formatLocalToJoplinCompatibleUnixTime(rawTodoDue, this.utils.getDateTimeFormat());
         }
 

--- a/src/variables/parser.ts
+++ b/src/variables/parser.ts
@@ -9,7 +9,7 @@ import { TimeCustomVariable } from "./types/time";
 
 // NOTE - InvalidCustomVariable should be at the last of the list
 // because it accepts any definition.
-const VARIABLE_TYPES = [
+const variableTypes = [
     TextCustomVariable,
     NumberCustomVariable,
     BooleanCustomVariable,
@@ -20,7 +20,7 @@ const VARIABLE_TYPES = [
 ];
 
 export const getVariableFromDefinition = (name: string, definition: unknown): CustomVariable => {
-    for (const variableType of VARIABLE_TYPES) {
+    for (const variableType of variableTypes) {
         try {
             const variable = variableType.createFromDefinition(name, definition);
             return variable;


### PR DESCRIPTION
## Summary
- refactor release script to use camelCase constants and tagName variable
- convert remaining all-caps constants to camelCase across source files

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cb362e8d4832980f5cd25019ae460