### PR TITLE
chore: clarify eslint disables and tidy fetch

### DIFF
--- a/src/helpers/helper.ts
+++ b/src/helpers/helper.ts
@@ -3,7 +3,7 @@ import { HelperContext } from "./context";
 
 export type HelperConstructorBlock = (ctx: HelperContext) => HandlebarsHelper;
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 type HelperImpl = (...args: Array<any>) => any;
 
 export class HandlebarsHelper {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -13,7 +13,7 @@ import { HelperFactory } from "./helpers";
 // Can't use import for this library because the types in the library
 // are declared incorrectly which result in typescript errors.
 // Reference -> https://github.com/jxson/front-matter/issues/76
-// eslint-disable-next-line @typescript-eslint/no-var-requires
+// eslint-disable-next-line @typescript-eslint/no-var-requires -- Old code before rule was applied
 const frontmatter = require("front-matter");
 
 export interface NewNote {
@@ -203,7 +203,7 @@ export class Parser {
 
         const wrapInQuotes = (definitionsBlock: string, properties: string[]) => {
             for (const prop of properties) {
-                // eslint-disable-next-line no-useless-escape
+                // eslint-disable-next-line no-useless-escape -- Old code before rule was applied
                 const pattern = new RegExp(`^[^\S\n]*${prop}[^\S\n]*:.*`, "gm");
                 const matches = definitionsBlock.match(pattern);
                 if (!matches) {

--- a/src/utils/dataApi.ts
+++ b/src/utils/dataApi.ts
@@ -1,14 +1,14 @@
 import joplin from "api";
 
-// eslint-disable-next-line
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 export const fetchAllItems = async (path: string[], query: any): Promise<any[]> => {
     let pageNum = 1;
-    let response;
-    let items = [];
+    let response: any;
+    const items: any[] = [];
 
     do {
         response = await joplin.data.get(path, { ...query, page: pageNum });
-        items = items.concat(response.items);
+        items.push(...response.items);
         pageNum++;
     } while (response.has_more);
 

--- a/src/variables/types/base.ts
+++ b/src/variables/types/base.ts
@@ -32,7 +32,7 @@ export class CustomVariable {
         );
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars -- Old code before rule was applied
     public processInput(input: string, dateAndTimeUtils: DateAndTimeUtils): any {
         return input;
     }

--- a/src/variables/types/boolean.ts
+++ b/src/variables/types/boolean.ts
@@ -16,7 +16,7 @@ export class BooleanCustomVariable extends CustomVariable {
         );
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Old code before rule was applied
     public processInput(input: string, dateAndTimeUtils: DateAndTimeUtils): boolean {
         return input === "true";
     }

--- a/src/variables/types/invalid.ts
+++ b/src/variables/types/invalid.ts
@@ -6,7 +6,7 @@ export class InvalidCustomVariable extends CustomVariable {
         return `<div class="invalidVariable"><i>${encode(this.name)} has an invalid type.</i></div>`;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Old code before rule was applied
     static createFromDefinition(name: string, definition: unknown): CustomVariable {
         return new this(name, name);
     }

--- a/src/variables/types/number.ts
+++ b/src/variables/types/number.ts
@@ -9,7 +9,7 @@ export class NumberCustomVariable extends CustomVariable {
         return `<input name="${encode(this.name)}" type="number"></input>`;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Old code before rule was applied
     public processInput(input: string, dateAndTimeUtils: DateAndTimeUtils): number {
         return Number.parseFloat(input);
     }

--- a/tests/mock-joplin-api.ts
+++ b/tests/mock-joplin-api.ts
@@ -1,19 +1,19 @@
 export default {
     commands: {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Old code before rule was applied
         execute: async (cmd: string, props: unknown): Promise<unknown> => { return ""; }
     },
     views: {
         dialogs: {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Old code before rule was applied
             showMessageBox: async (message: string): Promise<number> => { return 0; },
 
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Old code before rule was applied
             open: async (handle: string): Promise<unknown> => { return ""; }
         }
     },
     settings: {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Old code before rule was applied
         globalValue: async (setting: string): Promise<string> => { return ""; },
         value: async (setting: string): Promise<string> => { return ""; }
     },

--- a/tests/parser.spec.ts
+++ b/tests/parser.spec.ts
@@ -29,7 +29,7 @@ describe("Template parser", () => {
     const parser = new Parser(dateAndTimeUtils, "variable-dialog", logger);
 
     const testVariableTypes = (variableTypes: { [name: string]: typeof CustomVariable | typeof EnumCustomVariable }, extraValidations?: (varDict: { [name: string]: CustomVariable }) => void) => {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Old code before rule was applied
         jest.spyOn(templateVariableViews, "setTemplateVariablesView").mockImplementation(async (handle: string, title: string, variableDict: { [name: string]: CustomVariable }) => {
             for (const [name, variable] of Object.entries(variableDict)) {
                 expect(variable instanceof variableTypes[name]).toBeTruthy();
@@ -42,7 +42,7 @@ describe("Template parser", () => {
     };
 
     const handleVariableDialog = (id: "cancel" | "ok", variables: { [name: string]: string }) => {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Old code before rule was applied
         jest.spyOn(joplin.views.dialogs, "open").mockImplementation(async (handle: string) => {
             if (id === "cancel") {
                 return {

--- a/tests/utils/templates.spec.ts
+++ b/tests/utils/templates.spec.ts
@@ -18,7 +18,7 @@ interface TagData {
 }
 
 describe("Get user template selection", () => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Old code before rule was applied
     jest.spyOn(joplin.views.dialogs, "showMessageBox").mockImplementation(async (message: string) => {
         return 0;
     });
@@ -46,7 +46,7 @@ describe("Get user template selection", () => {
     };
 
     const setTemplateTagsAndNotes = (data: TagData[]) => {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Old code before rule was applied
         jest.spyOn(tagUtils, "getAllTagsWithTitle").mockImplementation(async (title: string) => {
             return data.map(tag => {
                 return {
@@ -66,7 +66,7 @@ describe("Get user template selection", () => {
         });
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
     const testExpectedCalls = (mockedFunction: any, expectedCalls: number): void => {
         expect(mockedFunction.mock.calls.length).toBe(expectedCalls);
     }


### PR DESCRIPTION
## Summary
- document remaining eslint-disable usages
- avoid array reassignment in fetchAllItems

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cb36b0bac83298e5de02ee04e2955