### PR TITLE
feat: add timeline view

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { PluginSettingsRegistry, DefaultNoteTemplateIdSetting, DefaultTodoTempla
 import { LocaleGlobalSetting, DateFormatGlobalSetting, TimeFormatGlobalSetting, ProfileDirGlobalSetting } from "./settings/global";
 import { DefaultTemplatesConfig } from "./settings/defaultTemplatesConfig";
 import templatesImportModule from "./importModule";
+import { setTimelineView, TimelineNote } from "./views/timeline";
 
 const documentationUrl = "https://github.com/joplin/plugin-templates#readme";
 
@@ -245,6 +246,18 @@ joplin.plugins.register({
         }));
 
         joplinCommands.add(joplin.commands.register({
+            name: "showTimeline",
+            label: "Show timeline",
+            execute: async () => {
+                const response: { items: TimelineNote[] } = await joplin.data.get([
+                    "notes"
+                ], { fields: ["id", "title", "created_time"], order_by: "created_time", order_dir: "ASC" }) as { items: TimelineNote[] };
+                await setTimelineView(dialogViewHandle, response.items);
+                await joplin.views.dialogs.open(dialogViewHandle);
+            }
+        }));
+
+        joplinCommands.add(joplin.commands.register({
             name: "showPluginDocumentation",
             label: "Help",
             execute: async () => {
@@ -288,6 +301,9 @@ joplin.plugins.register({
             {
                 commandName: "insertTemplate",
                 accelerator: "Alt+Ctrl+I"
+            },
+            {
+                commandName: "showTimeline"
             },
             {
                 label: "Default templates",

--- a/src/views/timeline.ts
+++ b/src/views/timeline.ts
@@ -1,0 +1,27 @@
+import joplin from "api";
+import { encode } from "html-entities";
+
+export interface TimelineNote {
+    id: string;
+    title: string;
+    created_time: number;
+}
+
+const formatDate = (timestamp: number): string => {
+    return new Date(timestamp).toLocaleDateString();
+};
+
+export const setTimelineView = async (viewHandle: string, notes: TimelineNote[]): Promise<void> => {
+    await joplin.views.dialogs.addScript(viewHandle, "./views/webview.css");
+
+    const html = `
+        <h2> Timeline </h2>
+        <ul class="timeline">
+            ${notes.map(note => `<li><span class="date">${formatDate(note.created_time)}</span>${encode(note.title)}</li>`).join("")}
+        </ul>
+    `;
+
+    await joplin.views.dialogs.setHtml(viewHandle, html);
+    await joplin.views.dialogs.setButtons(viewHandle, [{ id: "ok" }]);
+};
+

--- a/src/views/webview.css
+++ b/src/views/webview.css
@@ -36,3 +36,18 @@ input, select {
     max-height: 80vh;
     overflow: scroll;
 }
+
+.timeline {
+    list-style: none;
+    padding-left: 0;
+    text-align: left;
+}
+
+.timeline li {
+    margin: 8px 0;
+}
+
+.timeline .date {
+    font-weight: bold;
+    margin-right: 6px;
+}


### PR DESCRIPTION
## Summary
- add new timeline view to display notes by creation date
- style timeline list in shared webview stylesheet
- expose timeline view via command and menu option

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cb285e3648329b0e88a7bed4baccd