### PR TITLE
feat: auto-create note on file drop

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -107,6 +107,9 @@ joplin.plugins.register({
             }
         };
 
+        // Enable file drop by default so that dropped files create new notes automatically
+        fileDropListener = await (joplin.workspace as any).on("fileDrop", onFileDrop);
+
         // Register all commands
         const joplinCommands = new PromiseGroup();
 


### PR DESCRIPTION
## Summary
- automatically register file-drop handler so dropping files on the note list creates new notes with attachments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cc984b108832987e348b64337b291