### PR TITLE
Support image detection in file drop notes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -99,9 +99,10 @@ joplin.plugins.register({
             if (!event || !event.files) return;
             for (const file of event.files) {
                 const resource: any = await joplin.data.post(["resources"], file);
+                const isImage = resource.mime && resource.mime.startsWith("image/");
                 const note = {
                     title: file.name || "Dropped file",
-                    body: `[](:/${resource.id})`,
+                    body: isImage ? `![](:/${resource.id})` : `[${file.name || "Dropped file"}](:/${resource.id})`,
                 };
                 await joplin.data.post(["notes"], note);
             }


### PR DESCRIPTION
## Summary
- Detect dropped image files via MIME type
- Insert Markdown image syntax for images and link syntax for other files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cd6f35ab083299a50b5c4b6c669fb