### PR TITLE
Ensure dropped files go to selected notebook

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -97,11 +97,16 @@ joplin.plugins.register({
         let fileDropListener: any = null;
         const onFileDrop = async (event: any) => {
             if (!event || !event.files) return;
+
+            const folder = await joplin.workspace.selectedFolder();
+            if (!folder) return;
+
             for (const file of event.files) {
                 const resource: any = await joplin.data.post(["resources"], file);
                 const note = {
                     title: file.name || "Dropped file",
                     body: `[](:/${resource.id})`,
+                    parent_id: folder.id,
                 };
                 await joplin.data.post(["notes"], note);
             }


### PR DESCRIPTION
## Summary
- Make dropped files create notes in the currently selected notebook

## Testing
- `npm test`
- `npm run lint`
- manual: simulated file drop confirms note posted with selected folder


------
https://chatgpt.com/codex/tasks/task_e_689cd6f5ae208329abaf3ca81fd9ac29