### PR TITLE
refactor: declare readManifest before use

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -67,12 +67,12 @@ const currentGitInfo = () => {
 	}
 };
 
-const readManifest = (manifestPath) => {
-	const content = fs.readFileSync(manifestPath, 'utf8');
-	const output = JSON.parse(content);
-	if (!output.id) throw new Error(`Manifest plugin ID is not set in ${manifestPath}`);
-	return output;
-};
+function readManifest(manifestPath) {
+        const content = fs.readFileSync(manifestPath, 'utf8');
+        const output = JSON.parse(content);
+        if (!output.id) throw new Error(`Manifest plugin ID is not set in ${manifestPath}`);
+        return output;
+}
 
 const createPluginArchive = (sourceDir, destPath) => {
 	const distFiles = glob.sync(`${sourceDir}/**/*`, { nodir: true })


### PR DESCRIPTION
## Summary
- convert `readManifest` arrow to function declaration so it is defined before usage

## Testing
- `npm test`
- `npm run dist` *(fails: Property 'resourcePath' does not exist on type 'JoplinData')*

------
https://chatgpt.com/codex/tasks/task_e_689cd78039748329be36bc88d44cd7d6