### PR TITLE
Add tests for build manifest reading

### DIFF
--- a/tests/build.spec.ts
+++ b/tests/build.spec.ts
@@ -1,0 +1,33 @@
+import * as path from 'path';
+
+let fs: typeof import('fs-extra');
+
+describe('readManifest', () => {
+    const webpackConfigPath = path.resolve(__dirname, '..', 'webpack.config.js');
+    const manifestPath = path.resolve(__dirname, '..', 'src', 'manifest.json');
+    const originalArgv = process.argv;
+
+    beforeEach(() => {
+        jest.resetModules();
+        fs = require('fs-extra');
+        process.argv = ['node', 'webpack.config.js', '--joplin-plugin-config', 'buildMain'];
+    });
+
+    afterEach(() => {
+        process.argv = originalArgv;
+        jest.restoreAllMocks();
+    });
+
+    test('loads config when manifest is valid', () => {
+        expect(() => require(webpackConfigPath)).not.toThrow();
+    });
+
+    test('throws if manifest id is missing', () => {
+        const realReadFileSync = fs.readFileSync;
+        jest.spyOn(fs, 'readFileSync').mockImplementation((p: any, options: any) => {
+            if (p === manifestPath) return JSON.stringify({});
+            return realReadFileSync(p, options);
+        });
+        expect(() => require(webpackConfigPath)).toThrow(/Manifest plugin ID is not set/);
+    });
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -67,12 +67,18 @@ const currentGitInfo = () => {
 	}
 };
 
-const readManifest = (manifestPath) => {
-	const content = fs.readFileSync(manifestPath, 'utf8');
-	const output = JSON.parse(content);
-	if (!output.id) throw new Error(`Manifest plugin ID is not set in ${manifestPath}`);
-	return output;
-};
+/**
+ * Reads and validates the plugin manifest.
+ *
+ * Throws a descriptive error if the manifest file is missing, contains invalid JSON,
+ * or does not include the required `id` field.
+ */
+function readManifest(manifestPath) {
+        const content = fs.readFileSync(manifestPath, 'utf8');
+        const output = JSON.parse(content);
+        if (!output.id) throw new Error(`Manifest plugin ID is not set in ${manifestPath}`);
+        return output;
+}
 
 const createPluginArchive = (sourceDir, destPath) => {
 	const distFiles = glob.sync(`${sourceDir}/**/*`, { nodir: true })


### PR DESCRIPTION
## Summary
- ensure `readManifest` is defined before use
- add tests covering manifest reading and missing `id`
- document manifest reader error handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cd78207c08329bcb78007dd478dbc