### PR TITLE
Fix build script and file drop handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "joplin-plugin-templates",
   "version": "2.4.0",
   "scripts": {
-    "dist": "webpack --joplin-plugin-config buildMain && webpack --joplin-plugin-config buildExtraScripts && webpack --joplin-plugin-config createArchive",
+    "dist": "NODE_OPTIONS=--openssl-legacy-provider JOPLIN_PLUGIN_CONFIG=buildMain webpack && NODE_OPTIONS=--openssl-legacy-provider JOPLIN_PLUGIN_CONFIG=buildExtraScripts webpack && NODE_OPTIONS=--openssl-legacy-provider JOPLIN_PLUGIN_CONFIG=createArchive webpack",
     "prepare": "npm run dist",
     "update": "npm install -g generator-joplin && yo joplin --update",
     "lint": "eslint '{src,tests}/**/*.{ts,json}'",

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,13 +20,18 @@ import { processAttachment } from "./utils/attachmentProcessing";
 
 export const onFileDrop = async (event: any) => {
     if (!event || !event.files) return;
+
+    const folder = await joplin.workspace.selectedFolder();
+    if (!folder) return;
+
     for (const file of event.files) {
-        const resource: any = await joplin.data.post(["resources"], null, file);
+        const resource: any = await joplin.data.post(["resources"], file);
         const note = {
             title: file.name || "Dropped file",
             body: `[](:/${resource.id})`,
+            parent_id: folder.id,
         };
-        await joplin.data.post(["notes"], null, note);
+        await joplin.data.post(["notes"], note);
     }
 };
 
@@ -104,64 +109,9 @@ joplin.plugins.register({
             return (await notebookDisplayDataPromiseGroup.groupAll())[PromiseGroup.UNNAMED_KEY].filter(x => x !== null);
         }
 
-// File drop handling
-let fileDropListener: any = null;
 
-// File drop handling
-let fileDropListener: any = null;
-
-const onFileDrop = async (event: any) => {
-    if (!event || !event.files) return;
-
-    const folder = await joplin.workspace.selectedFolder();
-    if (!folder) return;
-
-    for (const file of event.files) {
-        const resource: any = await joplin.data.post(["resources"], file);
-        const isImage = resource.mime && resource.mime.startsWith("image/");
-        
-        const note = {
-            title: file.name || "Dropped file",
-            body: isImage ? `![](:/${resource.id})` : `[${file.name || "Dropped file"}](:/${resource.id})`,
-            parent_id: folder.id, // Set the parent_id to the selected folder
-        };
-
-        await joplin.data.post(["notes"], note);
-    }
-};
-
-// Add event listener for file drops
-fileDropListener = (event: DragEvent) => {
-    event.preventDefault();
-    onFileDrop(event);
-};
-
-// Assuming you have a target element to drop files onto
-const dropZone = document.getElementById("drop-zone");
-if (dropZone) {
-    dropZone.addEventListener("dragover", (event) => event.preventDefault());
-    dropZone.addEventListener("drop", fileDropListener);
-}
-
-        };
-
-        await joplin.data.post(["notes"], note);
-    }
-};
-
-// Add event listener for file drops
-fileDropListener = (event: DragEvent) => {
-    event.preventDefault();
-    onFileDrop(event);
-};
-
-// Assuming you have a target element to drop files onto
-const dropZone = document.getElementById("drop-zone");
-if (dropZone) {
-    dropZone.addEventListener("dragover", (event) => event.preventDefault());
-    dropZone.addEventListener("drop", fileDropListener);
-}
-
+        // File drop handling
+        let fileDropListener: any = null;
 
         // Enable file drop by default so that dropped files create new notes automatically
         fileDropListener = await (joplin.workspace as any).on("fileDrop", onFileDrop);

--- a/tests/fileDrop.spec.ts
+++ b/tests/fileDrop.spec.ts
@@ -4,7 +4,9 @@ import { onFileDrop } from "../src/index";
 describe("onFileDrop", () => {
     test("creates a resource and note for dropped files", async () => {
         const file = { name: "test.txt" } as any;
-        const postMock = jest.spyOn(joplin.data, "post").mockImplementation(async (path: string[], _query: any, data: any) => {
+        const selectedFolderMock = jest.fn().mockResolvedValue({ id: "folder1" });
+        (joplin as any).workspace = { selectedFolder: selectedFolderMock } as any;
+        const postMock = jest.spyOn(joplin.data, "post").mockImplementation(async (path: string[], data: any) => {
             if (path[0] === "resources") {
                 return { id: "res1" };
             }
@@ -16,11 +18,13 @@ describe("onFileDrop", () => {
 
         await onFileDrop({ files: [file] });
 
+        expect(selectedFolderMock).toHaveBeenCalledTimes(1);
         expect(postMock).toHaveBeenCalledTimes(2);
-        expect(postMock).toHaveBeenCalledWith(["resources"], null, file);
-        expect(postMock).toHaveBeenCalledWith(["notes"], null, {
+        expect(postMock).toHaveBeenCalledWith(["resources"], file);
+        expect(postMock).toHaveBeenCalledWith(["notes"], {
             title: "test.txt",
             body: "[](:/res1)",
+            parent_id: "folder1",
         });
     });
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -234,10 +234,10 @@ const buildExtraScriptConfigs = (userConfig) => {
 
 const main = (processArgv) => {
 	const yargs = require('yargs/yargs');
-	const argv = yargs(processArgv).argv;
+        const argv = yargs(processArgv).argv;
 
-	const configName = argv['joplin-plugin-config'];
-	if (!configName) throw new Error('A config file must be specified via the --joplin-plugin-config flag');
+        const configName = argv['joplin-plugin-config'] || process.env.JOPLIN_PLUGIN_CONFIG;
+        if (!configName) throw new Error('A config file must be specified via the --joplin-plugin-config flag or JOPLIN_PLUGIN_CONFIG environment variable');
 
 	// Webpack configurations run in parallel, while we need them to run in
 	// sequence, and to do that it seems the only way is to run webpack multiple


### PR DESCRIPTION
## Summary
- export and use a single `onFileDrop` handler that attaches dropped files to the selected notebook
- allow webpack config to read `JOPLIN_PLUGIN_CONFIG` env var and update build script with OpenSSL legacy option
- adjust file drop test for new API

## Testing
- `npm run dist`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cdfd595d083298382df2b9c6b2f31