### PR TITLE
Handle file drop errors

### DIFF
--- a/tests/fileDrop.spec.ts
+++ b/tests/fileDrop.spec.ts
@@ -1,7 +1,13 @@
 import joplin from "api";
 import { onFileDrop } from "../src/index";
+import { Logger } from "../src/logger";
+import * as folders from "../src/utils/folders";
 
 describe("onFileDrop", () => {
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
     test("creates a resource and note for dropped files", async () => {
         const file = { name: "test.txt" } as any;
         const selectedFolderMock = jest.fn().mockResolvedValue({ id: "folder1" });
@@ -26,5 +32,33 @@ describe("onFileDrop", () => {
             body: "[](:/res1)",
             parent_id: "folder1",
         });
+    });
+
+    test("prompts for notebook when none selected", async () => {
+        const file = { name: "test.txt" } as any;
+        const selectedFolderMock = jest.fn().mockResolvedValue(null);
+        (joplin as any).workspace = { selectedFolder: selectedFolderMock } as any;
+        const getUserFolderSelectionMock = jest.spyOn(folders, "getUserFolderSelection").mockResolvedValue(null);
+        const postMock = jest.spyOn(joplin.data, "post");
+
+        await onFileDrop({ files: [file] });
+
+        expect(getUserFolderSelectionMock).toHaveBeenCalledTimes(1);
+        expect(postMock).not.toHaveBeenCalled();
+    });
+
+    test("shows error and logs when creation fails", async () => {
+        const file = { name: "test.txt" } as any;
+        const selectedFolderMock = jest.fn().mockResolvedValue({ id: "folder1" });
+        (joplin as any).workspace = { selectedFolder: selectedFolderMock } as any;
+        jest.spyOn(joplin.data, "post").mockImplementation(async () => { throw new Error("fail"); });
+        jest.spyOn(joplin.settings, "globalValue").mockResolvedValue("/tmp");
+        const showMessageMock = jest.spyOn(joplin.views.dialogs, "showMessageBox").mockResolvedValue(0);
+        const logMock = jest.spyOn(Logger.prototype, "log").mockResolvedValue();
+
+        await onFileDrop({ files: [file] });
+
+        expect(showMessageMock).toHaveBeenCalledTimes(1);
+        expect(logMock).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
## Summary
- Prompt for target notebook when dropping files without an active selection
- Surface and log file drop failures via message box and Logger
- Test file drop error and no-notebook cases

## Testing
- `npm test`
- `npm run lint` *(fails: Strings must use doublequote)*

------
https://chatgpt.com/codex/tasks/task_e_689d09479354832995cfc7d895c1805c