### PR TITLE
Use official file drop event

### DIFF
--- a/api/JoplinWorkspace.d.ts
+++ b/api/JoplinWorkspace.d.ts
@@ -12,8 +12,12 @@ interface ItemChangeEvent {
 interface SyncStartEvent {
     withErrors: boolean;
 }
+interface FileDropEvent {
+    files: any[];
+}
 declare type ItemChangeHandler = (event: ItemChangeEvent)=> void;
 declare type SyncStartHandler = (event: SyncStartEvent)=> void;
+declare type FileDropHandler = (event: FileDropEvent)=> void;
 /**
  * The workspace service provides access to all the parts of Joplin that
  * are being worked on - i.e. the currently selected notes or notebooks as
@@ -50,6 +54,10 @@ export default class JoplinWorkspace {
      * Called when the synchronisation process has finished.
      */
     onSyncComplete(callback: Function): Promise<Disposable>;
+    /**
+     * Called when files are dropped into the application.
+     */
+    onFileDrop?(handler: FileDropHandler): Promise<Disposable>;
     /**
      * Gets the currently selected note
      */

--- a/api/types.ts
+++ b/api/types.ts
@@ -199,7 +199,7 @@ export interface Script {
 }
 
 export interface Disposable {
-	// dispose():void;
+        dispose(): void;
 }
 
 // =================================================================

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import joplin from "api";
-import { MenuItemLocation } from "api/types";
+import { MenuItemLocation, Disposable } from "api/types";
 import { Parser } from "./parser";
 import { DateAndTimeUtils } from "./utils/dateAndTime";
 import { getFolderFromId, getSelectedFolder, getUserFolderSelection, Folder } from "./utils/folders";
@@ -18,7 +18,7 @@ import templatesImportModule from "./importModule";
 import { setTimelineView, TimelineNote } from "./views/timeline";
 import { processAttachment } from "./utils/attachmentProcessing";
 
-export const onFileDrop = async (event: any) => {
+export const onFileDrop = async (event: { files: any[] } | null) => {
     if (!event || !event.files) return;
 
     const folder = await joplin.workspace.selectedFolder();
@@ -33,6 +33,14 @@ export const onFileDrop = async (event: any) => {
         };
         await joplin.data.post(["notes"], note);
     }
+};
+
+export const initializeFileDrop = async (): Promise<Disposable | null> => {
+    if (joplin.workspace?.onFileDrop) {
+        return await joplin.workspace.onFileDrop(onFileDrop);
+    }
+    await joplin.views.dialogs.showMessageBox("File drop is not supported in this version of Joplin.");
+    return null;
 };
 
 const documentationUrl = "https://github.com/joplin/plugin-templates#readme";
@@ -111,10 +119,10 @@ joplin.plugins.register({
 
 
         // File drop handling
-        let fileDropListener: any = null;
+        let fileDropListener: Disposable | null = null;
 
         // Enable file drop by default so that dropped files create new notes automatically
-        fileDropListener = await (joplin.workspace as any).on("fileDrop", onFileDrop);
+        fileDropListener = await initializeFileDrop();
 
         // Register all commands
         const joplinCommands = new PromiseGroup();
@@ -312,8 +320,10 @@ joplin.plugins.register({
                     fileDropListener = null;
                     await joplin.views.dialogs.showMessageBox("File drop disabled");
                 } else {
-                    fileDropListener = await (joplin.workspace as any).on("fileDrop", onFileDrop);
-                    await joplin.views.dialogs.showMessageBox("File drop enabled");
+                    fileDropListener = await initializeFileDrop();
+                    if (fileDropListener) {
+                        await joplin.views.dialogs.showMessageBox("File drop enabled");
+                    }
                 }
             }
         }));

--- a/tests/fileDrop.spec.ts
+++ b/tests/fileDrop.spec.ts
@@ -1,5 +1,5 @@
 import joplin from "api";
-import { onFileDrop } from "../src/index";
+import { onFileDrop, initializeFileDrop } from "../src/index";
 
 describe("onFileDrop", () => {
     test("creates a resource and note for dropped files", async () => {
@@ -26,5 +26,28 @@ describe("onFileDrop", () => {
             body: "[](:/res1)",
             parent_id: "folder1",
         });
+    });
+});
+
+describe("initializeFileDrop", () => {
+    test("subscribes to workspace.onFileDrop when available", async () => {
+        const disposable = { dispose: jest.fn() } as any;
+        const onFileDropMock = jest.fn().mockResolvedValue(disposable);
+        (joplin as any).workspace = { onFileDrop: onFileDropMock } as any;
+
+        const result = await initializeFileDrop();
+
+        expect(onFileDropMock).toHaveBeenCalledWith(onFileDrop);
+        expect(result).toBe(disposable);
+    });
+
+    test("shows warning when onFileDrop is unavailable", async () => {
+        (joplin as any).workspace = {} as any;
+        const messageMock = jest.spyOn(joplin.views.dialogs, "showMessageBox").mockResolvedValue(0);
+
+        const result = await initializeFileDrop();
+
+        expect(result).toBeNull();
+        expect(messageMock).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
## Summary
- switch to official `onFileDrop` workspace event with graceful fallback when unavailable
- declare workspace file-drop event in API typings and add `dispose` signature
- test subscription flow and warning for unsupported file-drop event

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d09453b1083299cd5a8657eb303a5