### PR TITLE
feat: add templates import module

### DIFF
--- a/src/importModule.ts
+++ b/src/importModule.ts
@@ -1,3 +1,4 @@
+import joplin from "api";
 import { ImportModule, FileSystemItem, ImportContext } from "api/types";
 
 const templatesImportModule: ImportModule = {
@@ -5,8 +6,37 @@ const templatesImportModule: ImportModule = {
     description: "Templates",
     isNoteArchive: false,
     sources: [FileSystemItem.File, FileSystemItem.Directory],
-    async onExec(_context: ImportContext): Promise<void> {
-        // TODO: implement template import logic
+    async onExec(context: ImportContext): Promise<void> {
+        const fs = joplin.require("fs-extra");
+        const path = joplin.require("path");
+
+        const createNote = async (filePath: string) => {
+            const raw = await fs.readFile(filePath, "utf8");
+            const firstLineIndex = raw.indexOf("\n");
+            const title = firstLineIndex >= 0
+                ? raw.slice(0, firstLineIndex).trim() || path.basename(filePath, path.extname(filePath))
+                : path.basename(filePath, path.extname(filePath));
+            const body = firstLineIndex >= 0 ? raw.slice(firstLineIndex + 1) : raw;
+
+            await joplin.data.post(["notes"], null, { title, body });
+        };
+
+        try {
+            const stat = await fs.stat(context.sourcePath);
+            if (stat.isDirectory()) {
+                const files = (await fs.readdir(context.sourcePath)).sort();
+                for (const file of files) {
+                    const filePath = path.join(context.sourcePath, file);
+                    if ((await fs.stat(filePath)).isFile()) {
+                        await createNote(filePath);
+                    }
+                }
+            } else {
+                await createNote(context.sourcePath);
+            }
+        } catch (error) {
+            await joplin.views.dialogs.showMessageBox(`Failed to import templates: ${error}`);
+        }
     },
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,9 +46,6 @@ export const onFileDrop = async (event: { files: any[] } | null) => {
     }
 };
 
-    }
-};
-
 export const initializeFileDrop = async (): Promise<Disposable | null> => {
     if (joplin.workspace?.onFileDrop) {
         return await joplin.workspace.onFileDrop(onFileDrop);

--- a/tests/fileDrop.spec.ts
+++ b/tests/fileDrop.spec.ts
@@ -1,5 +1,5 @@
 import joplin from "api";
-import { onFileDrop } from "../src/index";
+import { onFileDrop, initializeFileDrop } from "../src/index";
 import { Logger } from "../src/logger";
 import * as folders from "../src/utils/folders";
 

--- a/tests/templates-importModule.spec.ts
+++ b/tests/templates-importModule.spec.ts
@@ -1,0 +1,53 @@
+import joplin from "api";
+import templatesImportModule from "@templates/importModule";
+import * as fs from "fs-extra";
+import * as os from "os";
+import * as path from "path";
+
+describe("templates import module", () => {
+    beforeEach(() => {
+        (joplin as any).require = require;
+    });
+
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    test("imports markdown file as note", async () => {
+        const dir = await fs.mkdtemp(path.join(os.tmpdir(), "tmpl-"));
+        const file = path.join(dir, "note.md");
+        await fs.writeFile(file, "Title\nBody text");
+
+        const postMock = jest.spyOn(joplin.data, "post").mockResolvedValue({});
+
+        await templatesImportModule.onExec({ sourcePath: file } as any);
+
+        expect(postMock).toHaveBeenCalledWith(["notes"], null, {
+            title: "Title",
+            body: "Body text",
+        });
+        expect(postMock).toHaveBeenCalledTimes(1);
+    });
+
+    test("imports all files in directory", async () => {
+        const dir = await fs.mkdtemp(path.join(os.tmpdir(), "tmpl-"));
+        const fileA = path.join(dir, "a.md");
+        const fileB = path.join(dir, "b.md");
+        await fs.writeFile(fileA, "A\nBodyA");
+        await fs.writeFile(fileB, "B\nBodyB");
+
+        const postMock = jest.spyOn(joplin.data, "post").mockResolvedValue({});
+
+        await templatesImportModule.onExec({ sourcePath: dir } as any);
+
+        expect(postMock).toHaveBeenNthCalledWith(1, ["notes"], null, {
+            title: "A",
+            body: "BodyA",
+        });
+        expect(postMock).toHaveBeenNthCalledWith(2, ["notes"], null, {
+            title: "B",
+            body: "BodyB",
+        });
+        expect(postMock).toHaveBeenCalledTimes(2);
+    });
+});


### PR DESCRIPTION
## Summary
- implement import module to read files or directories and create notes
- add tests covering file and directory imports
- fix fileDrop tests to import initializeFileDrop

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d0b6365408329aa23d83686052458