### PR TITLE
refactor promise group API for clarity

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { TemplateAction, performAction } from "./actions";
 import { loadLegacyTemplates } from "./legacyTemplates";
 import * as open from "open";
 import { Logger } from "./logger";
-import { PromiseGroup } from "./utils/promises";
+import { PromiseGroup, NamedPromiseGroup } from "./utils/promises";
 import { PluginSettingsRegistry, DefaultNoteTemplateIdSetting, DefaultTodoTemplateIdSetting, DefaultTemplatesConfigSetting } from "./settings";
 import { LocaleGlobalSetting, DateFormatGlobalSetting, TimeFormatGlobalSetting, ProfileDirGlobalSetting } from "./settings/global";
 import { DefaultTemplatesConfig } from "./settings/defaultTemplatesConfig";
@@ -46,9 +46,6 @@ export const onFileDrop = async (event: { files: any[] } | null) => {
     }
 };
 
-    }
-};
-
 export const initializeFileDrop = async (): Promise<Disposable | null> => {
     if (joplin.workspace?.onFileDrop) {
         return await joplin.workspace.onFileDrop(onFileDrop);
@@ -66,18 +63,18 @@ joplin.plugins.register({
 
 
         // Global variables
-        const joplinGlobalApis = new PromiseGroup();
+        const joplinGlobalApis = new NamedPromiseGroup();
 
-        joplinGlobalApis.set("dialogViewHandle", joplin.views.dialogs.create("dialog"));
-        joplinGlobalApis.set("userLocale", LocaleGlobalSetting.get());
-        joplinGlobalApis.set("userDateFormat", DateFormatGlobalSetting.get());
-        joplinGlobalApis.set("userTimeFormat", TimeFormatGlobalSetting.get());
-        joplinGlobalApis.set("profileDir", ProfileDirGlobalSetting.get());
+        joplinGlobalApis.add("dialogViewHandle", joplin.views.dialogs.create("dialog"));
+        joplinGlobalApis.add("userLocale", LocaleGlobalSetting.get());
+        joplinGlobalApis.add("userDateFormat", DateFormatGlobalSetting.get());
+        joplinGlobalApis.add("userTimeFormat", TimeFormatGlobalSetting.get());
+        joplinGlobalApis.add("profileDir", ProfileDirGlobalSetting.get());
 
         const {
             dialogViewHandle, userLocale, userDateFormat,
             userTimeFormat, profileDir
-        } = await joplinGlobalApis.groupAll();
+        } = await joplinGlobalApis.all();
 
         const dateAndTimeUtils = new DateAndTimeUtils(userLocale, userDateFormat, userTimeFormat);
         const logger = new Logger(profileDir);
@@ -105,11 +102,11 @@ joplin.plugins.register({
 
         const getNotebookDefaultTemplatesDisplayData = async (settings: DefaultTemplatesConfig): Promise<NotebookDefaultTemplatesDisplayData[]> => {
             const getDisplayDataForNotebook = async (notebookId: string, defaultTemplateNoteId: string | null, defaultTemplateTodoId: string | null): Promise<NotebookDefaultTemplatesDisplayData | null> => {
-                const promiseGroup = new PromiseGroup();
-                promiseGroup.set("notebook", getFolderFromId(notebookId));
-                promiseGroup.set("noteTemplate", getTemplateFromId(defaultTemplateNoteId));
-                promiseGroup.set("todoTemplate", getTemplateFromId(defaultTemplateTodoId));
-                const { notebook, noteTemplate, todoTemplate } = await promiseGroup.groupAll();
+                const promiseGroup = new NamedPromiseGroup();
+                promiseGroup.add("notebook", getFolderFromId(notebookId));
+                promiseGroup.add("noteTemplate", getTemplateFromId(defaultTemplateNoteId));
+                promiseGroup.add("todoTemplate", getTemplateFromId(defaultTemplateTodoId));
+                const { notebook, noteTemplate, todoTemplate } = await promiseGroup.all();
 
                 if (notebook === null || (noteTemplate === null && todoTemplate === null)) {
                     // Async remove of the obsolete config
@@ -128,7 +125,7 @@ joplin.plugins.register({
                 notebookDisplayDataPromiseGroup.add(getDisplayDataForNotebook(
                     notebookId, defaultTemplates.defaultNoteTemplateId, defaultTemplates.defaultTodoTemplateId));
             }
-            return (await notebookDisplayDataPromiseGroup.groupAll())[PromiseGroup.UNNAMED_KEY].filter(x => x !== null);
+            return (await notebookDisplayDataPromiseGroup.all()).filter(x => x !== null);
         }
 
 
@@ -423,7 +420,7 @@ joplin.plugins.register({
             MenuItemLocation.View
         );
 
-        await joplinCommands.groupAll();
+        await joplinCommands.all();
 
 
         // Folder context menu

--- a/tests/fileDrop.spec.ts
+++ b/tests/fileDrop.spec.ts
@@ -1,5 +1,5 @@
 import joplin from "api";
-import { onFileDrop } from "../src/index";
+import { onFileDrop, initializeFileDrop } from "../src/index";
 import { Logger } from "../src/logger";
 import * as folders from "../src/utils/folders";
 

--- a/tests/utils/promises.spec.ts
+++ b/tests/utils/promises.spec.ts
@@ -1,0 +1,26 @@
+import { PromiseGroup, NamedPromiseGroup } from "@templates/utils/promises";
+
+describe("Promise groups", () => {
+    test("PromiseGroup resolves promises in order", async () => {
+        const group = new PromiseGroup();
+        group.add(Promise.resolve(1));
+        group.add(Promise.resolve(2));
+        const results = await group.all();
+        expect(results).toEqual([1, 2]);
+    });
+
+    test("NamedPromiseGroup resolves to object keyed by names", async () => {
+        const group = new NamedPromiseGroup();
+        group.add("a", Promise.resolve(1));
+        group.add("b", Promise.resolve(2));
+        const results = await group.all();
+        expect(results).toEqual({ a: 1, b: 2 });
+    });
+
+    test("NamedPromiseGroup throws on duplicate key", () => {
+        const group = new NamedPromiseGroup();
+        group.add("dup", Promise.resolve(1));
+        expect(() => group.add("dup", Promise.resolve(2))).toThrow();
+    });
+});
+


### PR DESCRIPTION
## Summary
- refactor PromiseGroup into separate unnamed and named variants
- adapt index to use NamedPromiseGroup and simplified PromiseGroup
- add tests for new PromiseGroup behavior

## Testing
- `npm test`
- `npm run lint` *(fails: Strings must use doublequote, Unexpected empty arrow function)*

------
https://chatgpt.com/codex/tasks/task_e_689d0b662f7c8329bfc4f6ab0599ae92