### PR TITLE
fix: avoid optional chaining for file drop

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ export const onFileDrop = async (event: { files: any[] } | null) => {
 };
 
 export const initializeFileDrop = async (): Promise<Disposable | null> => {
-    if (joplin.workspace?.onFileDrop) {
+    if (joplin.workspace && joplin.workspace.onFileDrop) {
         return await joplin.workspace.onFileDrop(onFileDrop);
     }
     await joplin.views.dialogs.showMessageBox("File drop is not supported in this version of Joplin.");


### PR DESCRIPTION
## Summary
- replace joplin.workspace?.onFileDrop with explicit checks to avoid optional chaining

## Testing
- `npm run dist`

------
https://chatgpt.com/codex/tasks/task_e_689d12e49634832989a33247a6d55801