### PR TITLE
Handle missing selected folder

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -25,10 +25,15 @@ const performInsertTextAction = async (template: NewNote) => {
 
 const performNewNoteAction = async (template: NewNote, isTodo: 0 | 1) => {
     const folderId = template.folder ? template.folder : await getSelectedFolder();
-    const notePayload = { body: template.body, parent_id: folderId, title: template.title, is_todo: isTodo };
+    if (!folderId) {
+        await joplin.views.dialogs.showMessageBox("Please select a notebook first.");
+        return;
+    }
+
+    const notePayload: { body: string; parent_id: string; title: string; is_todo: 0 | 1; todo_due?: number | null } = { body: template.body, parent_id: folderId, title: template.title, is_todo: isTodo };
 
     if (isTodo && template.todo_due) {
-        notePayload["todo_due"] = template.todo_due;
+        notePayload.todo_due = template.todo_due;
     }
 
     const note = await joplin.data.post(["notes"], null, notePayload);

--- a/src/index.ts
+++ b/src/index.ts
@@ -234,6 +234,10 @@ joplin.plugins.register({
 
                 const defaultTemplatesConfig = await DefaultTemplatesConfigSetting.get();
                 const currentFolderId = await getSelectedFolder();
+                if (currentFolderId === null) {
+                    await joplin.views.dialogs.showMessageBox("Please select a notebook to use default templates.");
+                    return;
+                }
 
                 if (currentFolderId in defaultTemplatesConfig) {
                     defaultTemplate = await getTemplateFromId(defaultTemplatesConfig[currentFolderId].defaultNoteTemplateId);
@@ -258,6 +262,10 @@ joplin.plugins.register({
 
                 const defaultTemplatesConfig = await DefaultTemplatesConfigSetting.get();
                 const currentFolderId = await getSelectedFolder();
+                if (currentFolderId === null) {
+                    await joplin.views.dialogs.showMessageBox("Please select a notebook to use default templates.");
+                    return;
+                }
 
                 if (currentFolderId in defaultTemplatesConfig) {
                     defaultTemplate = await getTemplateFromId(defaultTemplatesConfig[currentFolderId].defaultTodoTemplateId);

--- a/src/utils/folders.ts
+++ b/src/utils/folders.ts
@@ -9,8 +9,11 @@ export interface Folder {
 
 type FolderProperty = "id" | "title";
 
-export const getSelectedFolder = async (): Promise<string> => {
+export const getSelectedFolder = async (): Promise<string | null> => {
     const folder = await joplin.workspace.selectedFolder();
+    if (!folder) {
+        return null;
+    }
     return folder.id;
 }
 

--- a/tests/actions.spec.ts
+++ b/tests/actions.spec.ts
@@ -1,0 +1,41 @@
+import joplin from "api";
+import { performAction, TemplateAction } from "../src/actions";
+import { NewNote } from "../src/parser";
+
+describe("performAction with no selected folder", () => {
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    const baseTemplate: NewNote = {
+        title: "test",
+        body: "body",
+        tags: [],
+        folder: null,
+        todo_due: null,
+    };
+
+    test("shows message when creating note without selected folder", async () => {
+        const selectedFolderMock = jest.fn().mockResolvedValue(null);
+        (joplin as unknown as { workspace: { selectedFolder: jest.Mock } }).workspace = { selectedFolder: selectedFolderMock };
+        const showMessageMock = jest.spyOn(joplin.views.dialogs, "showMessageBox").mockResolvedValue(0);
+        const postMock = jest.spyOn(joplin.data, "post");
+
+        await performAction(TemplateAction.NewNote, baseTemplate);
+
+        expect(showMessageMock).toHaveBeenCalled();
+        expect(postMock).not.toHaveBeenCalled();
+    });
+
+    test("shows message when creating todo without selected folder", async () => {
+        const selectedFolderMock = jest.fn().mockResolvedValue(null);
+        (joplin as unknown as { workspace: { selectedFolder: jest.Mock } }).workspace = { selectedFolder: selectedFolderMock };
+        const showMessageMock = jest.spyOn(joplin.views.dialogs, "showMessageBox").mockResolvedValue(0);
+        const postMock = jest.spyOn(joplin.data, "post");
+
+        await performAction(TemplateAction.NewTodo, baseTemplate);
+
+        expect(showMessageMock).toHaveBeenCalled();
+        expect(postMock).not.toHaveBeenCalled();
+    });
+});

--- a/tests/utils/folders.spec.ts
+++ b/tests/utils/folders.spec.ts
@@ -1,0 +1,28 @@
+import joplin from "api";
+import { getSelectedFolder } from "../../src/utils/folders";
+
+describe("getSelectedFolder", () => {
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    test("returns folder id when a folder is selected", async () => {
+        const selectedFolderMock = jest.fn().mockResolvedValue({ id: "folder1" });
+        (joplin as unknown as { workspace: { selectedFolder: jest.Mock } }).workspace = { selectedFolder: selectedFolderMock };
+
+        const result = await getSelectedFolder();
+
+        expect(selectedFolderMock).toHaveBeenCalled();
+        expect(result).toBe("folder1");
+    });
+
+    test("returns null when no folder is selected", async () => {
+        const selectedFolderMock = jest.fn().mockResolvedValue(null);
+        (joplin as unknown as { workspace: { selectedFolder: jest.Mock } }).workspace = { selectedFolder: selectedFolderMock };
+
+        const result = await getSelectedFolder();
+
+        expect(selectedFolderMock).toHaveBeenCalled();
+        expect(result).toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary
- return `null` from getSelectedFolder when no notebook is selected
- guard default template and new note actions against missing notebook selections
- test behaviors when no notebook is selected

## Testing
- `npm test`
- `npm run lint` *(fails: 62 problems in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689d12e4b6c083298668382e0874d92c