### PR TITLE
feat: process PDF attachments asynchronously

### DIFF
--- a/src/utils/attachmentProcessing.ts
+++ b/src/utils/attachmentProcessing.ts
@@ -33,7 +33,7 @@ export async function processAttachment(resourceId: string, noteId: string): Pro
             }
 
             const resourcePath: string = await joplin.data.resourcePath(resourceId);
-            const dataBuffer = fs.readFileSync(resourcePath);
+            const dataBuffer = await fs.promises.readFile(resourcePath);
             const pdfData = await pdfParse(dataBuffer);
             const sentences = pdfData.text.replace(/\s+/g, " ").split(/(?<=[.!?])\s+/).slice(0, 2).join(" ");
             const note: any = await joplin.data.get(["notes", noteId], { fields: ["id", "body"] });

--- a/tests/mock-joplin-api.ts
+++ b/tests/mock-joplin-api.ts
@@ -22,6 +22,10 @@ export default {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Old code before rule was applied
         post: async (path: string[], query: unknown, body: unknown): Promise<unknown> => { return {}; },
         // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Old code before rule was applied
+        get: async (path: string[], query: unknown): Promise<unknown> => { return {}; },
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Old code before rule was applied
+        put: async (path: string[], query: unknown, body: unknown): Promise<unknown> => { return {}; },
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Old code before rule was applied
         resourcePath: async (id: string): Promise<string> => { return ""; },
     },
     plugins: {

--- a/tests/utils/attachmentProcessing.spec.ts
+++ b/tests/utils/attachmentProcessing.spec.ts
@@ -1,0 +1,39 @@
+import joplin from "api";
+import * as fs from "fs";
+import { processAttachment } from "@templates/utils/attachmentProcessing";
+
+jest.mock("pdf-parse", () => {
+    return jest.fn(async () => ({ text: "First sentence. Second sentence. Third sentence." }));
+}, { virtual: true });
+
+const pdfParse = require("pdf-parse");
+
+describe("processAttachment PDF handling", () => {
+    test("reads PDF asynchronously and updates note body", async () => {
+        const resourceId = "res1";
+        const noteId = "note1";
+
+        const readFileSpy = jest.spyOn(fs.promises, "readFile").mockResolvedValue(Buffer.from("PDF"));
+
+        jest.spyOn(joplin.data, "get").mockImplementation(async (path: string[]) => {
+            if (path[0] === "resources") {
+                return { id: resourceId, mime: "application/pdf" };
+            }
+            if (path[0] === "notes") {
+                return { id: noteId, body: "Original body" };
+            }
+            return null;
+        });
+
+        jest.spyOn(joplin.data, "resourcePath").mockResolvedValue("/path/to/resource");
+        const putSpy = jest.spyOn(joplin.data, "put").mockResolvedValue({});
+
+        await processAttachment(resourceId, noteId);
+
+        expect(readFileSpy).toHaveBeenCalledWith("/path/to/resource");
+        expect(pdfParse).toHaveBeenCalled();
+        expect(putSpy).toHaveBeenCalledWith(["notes", noteId], null, {
+            body: "First sentence. Second sentence.\n\nOriginal body",
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- switch PDF processing to use async `fs.promises.readFile`
- extend mock Joplin data API with `get`/`put`
- add tests for asynchronous PDF attachment processing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d12e5c1088329813e097e10e17569