### PR TITLE
Replace moment with dayjs and drop legacy OpenSSL flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The currently supported built in template variables are:
 | `{{date}}` | Today's date  | 2019-01-01 |
 | `{{time}}` | Current time  | 13:00 |
 | `{{datetime}}` | Current date and time  | 01/01/19 1:00 PM |
-| `{{#custom_datetime}}` | Current date and/or time formatted based on a supplied string (using [moment.js](https://momentjs.com/) formatting) | `{{#custom_datetime}}M d{{/custom_datetime}}` |
+| `{{#custom_datetime}}` | Current date and/or time formatted based on a supplied string (using [dayjs](https://day.js.org/) formatting) | `{{#custom_datetime}}M d{{/custom_datetime}}` |
 | `{{bowm}}` | Date of the beginning of the week (when week starts on Monday) | |
 | `{{bows}}` | Date of the beginning of the week (when week starts on Sunday) | |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
+        "dayjs": "^1.11.13",
         "front-matter": "^4.0.2",
         "handlebars": "^4.7.7",
         "html-entities": "^2.3.2",
-        "moment": "^2.29.1",
         "open": "^8.2.1"
       },
       "devDependencies": {
@@ -2966,6 +2966,12 @@
         "node": "*"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -5896,14 +5902,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "joplin-plugin-templates",
   "version": "2.4.0",
   "scripts": {
-    "dist": "NODE_OPTIONS=--openssl-legacy-provider JOPLIN_PLUGIN_CONFIG=buildMain webpack && NODE_OPTIONS=--openssl-legacy-provider JOPLIN_PLUGIN_CONFIG=buildExtraScripts webpack && NODE_OPTIONS=--openssl-legacy-provider JOPLIN_PLUGIN_CONFIG=createArchive webpack",
+    "dist": "JOPLIN_PLUGIN_CONFIG=buildMain webpack && JOPLIN_PLUGIN_CONFIG=buildExtraScripts webpack && JOPLIN_PLUGIN_CONFIG=createArchive webpack",
     "prepare": "npm run dist",
     "update": "npm install -g generator-joplin && yo joplin --update",
     "lint": "eslint '{src,tests}/**/*.{ts,json}'",
@@ -50,10 +50,10 @@
     "yargs": "^17.7.2"
   },
   "dependencies": {
+    "dayjs": "^1.11.13",
     "front-matter": "^4.0.2",
     "handlebars": "^4.7.7",
     "html-entities": "^2.3.2",
-    "moment": "^2.29.1",
     "open": "^8.2.1"
   }
 }

--- a/src/helpers/datetime.ts
+++ b/src/helpers/datetime.ts
@@ -1,6 +1,6 @@
 import { HandlebarsHelper, HelperConstructorBlock } from "./helper";
 import { AttributeValueType, AttributeDefinition, AttributeParser } from "./utils/attributes";
-import moment from "moment";
+import dayjs from "dayjs";
 
 const format = "format";
 const setDate = "set_date";
@@ -65,29 +65,29 @@ export const datetimeHelper: HelperConstructorBlock = (ctx) => {
         const parser = new AttributeParser(schema);
         const attrs = parser.parse(options.hash);
 
-        const now = moment(new Date().getTime());
+        let now = dayjs(new Date().getTime());
 
         if (attrs[setDate]) {
             const parsedDate = ctx.dateAndTimeUtils.parseDate(attrs[setDate] as string, ctx.dateAndTimeUtils.getDateFormat());
-            now.set("date", parsedDate.date);
-            now.set("month", parsedDate.month);
-            now.set("year", parsedDate.year);
+            now = now.set("date", parsedDate.date);
+            now = now.set("month", parsedDate.month);
+            now = now.set("year", parsedDate.year);
         }
 
         if (attrs[setTime]) {
             const parsedTime = ctx.dateAndTimeUtils.parseTime(attrs[setTime] as string, ctx.dateAndTimeUtils.getTimeFormat());
-            now.set("hours", parsedTime.hours);
-            now.set("minutes", parsedTime.minutes);
-            now.set("seconds", parsedTime.seconds);
-            now.set("milliseconds", 0);
+            now = now.set("hour", parsedTime.hours);
+            now = now.set("minute", parsedTime.minutes);
+            now = now.set("second", parsedTime.seconds);
+            now = now.set("millisecond", 0);
         }
 
-        now.add(attrs[deltaYears] as number, "years");
-        now.add(attrs[deltaMonths] as number, "months");
-        now.add(attrs[deltaDays] as number, "days");
-        now.add(attrs[deltaHours] as number, "hours");
-        now.add(attrs[deltaMinutes] as number, "minutes");
-        now.add(attrs[deltaSeconds] as number, "seconds");
+        now = now.add(attrs[deltaYears] as number, "year");
+        now = now.add(attrs[deltaMonths] as number, "month");
+        now = now.add(attrs[deltaDays] as number, "day");
+        now = now.add(attrs[deltaHours] as number, "hour");
+        now = now.add(attrs[deltaMinutes] as number, "minute");
+        now = now.add(attrs[deltaSeconds] as number, "second");
 
         return ctx.dateAndTimeUtils.formatMsToLocal(now.toDate().getTime(), attrs[format] as string);
     });

--- a/src/utils/dateAndTime.ts
+++ b/src/utils/dateAndTime.ts
@@ -1,4 +1,9 @@
-import moment from "moment";
+import dayjs from "dayjs";
+import customParseFormat from "dayjs/plugin/customParseFormat";
+import advancedFormat from "dayjs/plugin/advancedFormat";
+
+dayjs.extend(customParseFormat);
+dayjs.extend(advancedFormat);
 
 // These are meant to parse the date and time formats
 // supported by Joplin. It doesn't support seconds or
@@ -25,7 +30,7 @@ export class DateAndTimeUtils {
         this.dateFormat = dateFormat;
         this.timeFormat = timeFormat;
 
-        moment.locale(this.locale);
+        dayjs.locale(this.locale);
     }
 
     public getDateFormat(): string {
@@ -44,7 +49,7 @@ export class DateAndTimeUtils {
         if (!format) {
             format = this.getDateTimeFormat();
         }
-        return moment(ms).format(format);
+        return dayjs(ms).format(format.replace(/\[\]/g, ""));
     }
 
     public formatLocalToJoplinCompatibleUnixTime(input: string, format: string | null = null): number {
@@ -52,7 +57,11 @@ export class DateAndTimeUtils {
             format = this.getDateTimeFormat();
         }
 
-        const date = moment(input, format, true);
+        let date = dayjs(input, format, true);
+        if (!date.isValid() && format.includes("HH") && /a/i.test(format)) {
+            const altFormat = format.replace("HH", "hh");
+            date = dayjs(input, altFormat, true);
+        }
         if (!date.isValid()) {
             throw new Error(`Was not able to parse ${input} according to format ${format}`);
         }
@@ -73,7 +82,11 @@ export class DateAndTimeUtils {
     }
 
     public parseDate(input: string, format: string): ParsedDate {
-        const date = moment(input, format, true);
+        let date = dayjs(input, format, true);
+        if (!date.isValid() && format.includes("HH") && /a/i.test(format)) {
+            const altFormat = format.replace("HH", "hh");
+            date = dayjs(input, altFormat, true);
+        }
 
         if (!date.isValid()) {
             throw new Error(`Was not able to parse ${input} according to format ${format}`);
@@ -87,16 +100,20 @@ export class DateAndTimeUtils {
     }
 
     public parseTime(input: string, format: string): ParsedTime {
-        const time = moment(input, format, true);
+        let time = dayjs(input, format, true);
+        if (!time.isValid() && format.includes("HH") && /a/i.test(format)) {
+            const altFormat = format.replace("HH", "hh");
+            time = dayjs(input, altFormat, true);
+        }
 
         if (!time.isValid()) {
             throw new Error(`Was not able to parse ${input} according to format ${format}`);
         }
 
         return {
-            hours: time.hours(),
-            minutes: time.minutes(),
-            seconds: time.seconds(),
+            hours: time.hour(),
+            minutes: time.minute(),
+            seconds: time.second(),
         };
     }
 }


### PR DESCRIPTION
## Summary
- replace Moment.js with the lighter Day.js library
- remove `NODE_OPTIONS=--openssl-legacy-provider` from build script
- document Day.js formatting support

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type, Strings must use doublequote, Require statement not part of import statement)*
- `npm run dist`


------
https://chatgpt.com/codex/tasks/task_e_689e41ebb1848329b095d5fc056aa77e