### PR TITLE
Use explicit query param when uploading dropped files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,13 +35,13 @@ export const onFileDrop = async (event: { files: any[] } | null) => {
 
         for (const file of event.files) {
             const promise = (async () => {
-                const resource: any = await joplin.data.post(["resources"], file);
+                const resource: any = await joplin.data.post(["resources"], null, file);
                 const note = {
                     title: file.name || "Dropped file",
                     body: `[](:/${resource.id})`,
                     parent_id: folder.id,
                 };
-                await joplin.data.post(["notes"], note);
+                await joplin.data.post(["notes"], null, note);
             })();
             promises.push(promise);
         }


### PR DESCRIPTION
## Summary
- Ensure file drop uploads resources with an explicit null query and file body
- Adjust note creation to pass body via third argument
- Update file drop tests to mock new signature and verify query/body usage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0dfb7cdfc8329bdee5d035d9880b4