### PR TITLE
Handle file drop registration with try/catch

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -56,11 +56,12 @@ export const onFileDrop = async (event: { files: any[] } | null) => {
 };
 
 export const initializeFileDrop = async (): Promise<Disposable | null> => {
-    if (joplin.workspace && joplin.workspace.onFileDrop) {
-        return await joplin.workspace.onFileDrop(onFileDrop);
+    try {
+        return await (joplin.workspace as any).onFileDrop(onFileDrop);
+    } catch {
+        await joplin.views.dialogs.showMessageBox("File drop is not supported in this version of Joplin.");
+        return null;
     }
-    await joplin.views.dialogs.showMessageBox("File drop is not supported in this version of Joplin.");
-    return null;
 };
 
 export const importTemplateFromFile = async (): Promise<void> => {


### PR DESCRIPTION
## Summary
- avoid property probing when registering file drop handler
- fall back to warning when file drop isn't supported

## Testing
- `npm test`
- `npm run dist`

------
https://chatgpt.com/codex/tasks/task_e_68a0edfb58e88329a9293349d5eca8cf