### PR TITLE
feat: add timeline panel

### DIFF
--- a/src/views/timeline.ts
+++ b/src/views/timeline.ts
@@ -12,16 +12,23 @@ const formatDate = (timestamp: number): string => {
 };
 
 export const setTimelineView = async (viewHandle: string, notes: TimelineNote[]): Promise<void> => {
-    await joplin.views.dialogs.addScript(viewHandle, "./views/webview.css");
+    await joplin.views.panels.addScript(viewHandle, "./views/webview.css");
+
+    const stripHtml = notes
+        .map(note => `<span class="timeline-strip-item" data-id="${note.id}">${formatDate(note.created_time)}</span>`) 
+        .join("");
+
+    const notesHtml = notes
+        .map(note => `<div class="timeline-note" data-id="${note.id}">${encode(note.title)}</div>`)
+        .join("");
 
     const html = `
-        <h2> Timeline </h2>
-        <ul class="timeline">
-            ${notes.map(note => `<li><span class="date">${formatDate(note.created_time)}</span>${encode(note.title)}</li>`).join("")}
-        </ul>
+        <div class="timeline-container">
+            <div class="timeline-strip">${stripHtml}</div>
+            <div class="timeline-notes">${notesHtml}</div>
+        </div>
     `;
 
-    await joplin.views.dialogs.setHtml(viewHandle, html);
-    await joplin.views.dialogs.setButtons(viewHandle, [{ id: "ok" }]);
+    await joplin.views.panels.setHtml(viewHandle, html);
 };
 

--- a/src/views/webview.css
+++ b/src/views/webview.css
@@ -37,17 +37,34 @@ input, select {
     overflow: scroll;
 }
 
-.timeline {
-    list-style: none;
-    padding-left: 0;
+/* Timeline panel layout */
+.timeline-container {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+}
+
+.timeline-strip {
+    display: flex;
+    overflow-x: auto;
+    position: sticky;
+    top: 0;
+    background: var(--joplin-background-color);
+    padding: 4px;
+}
+
+.timeline-strip-item {
+    margin-right: 8px;
+    white-space: nowrap;
+}
+
+.timeline-notes {
+    flex: 1;
+    overflow-y: auto;
     text-align: left;
+    padding: 8px;
 }
 
-.timeline li {
-    margin: 8px 0;
-}
-
-.timeline .date {
-    font-weight: bold;
-    margin-right: 6px;
+.timeline-note {
+    margin-bottom: 8px;
 }


### PR DESCRIPTION
## Summary
- switch timeline from dialog to top-mounted panel
- render notes and strip in panel with updated layout
- refresh panel when notes change

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0f8bd46188329bd34d35f21cc022a