### PR TITLE
chore: require Joplin 2.12.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This plugin allows you to create templates in Joplin and use them to create new 
 - [Contributing](#contributing)
 
 ## Installing Plugin
+Janis requires Joplin **2.12.2 or later**. Please upgrade Joplin before installing the plugin.
 - Open Joplin
 - Go to Tools > Options > Plugins
 - Search for `Janis`

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 1,
     "id": "joplin.plugin.janis",
-    "app_min_version": "2.2.5",
+    "app_min_version": "2.12.2",
     "version": "2.4.0",
     "name": "Janis",
     "description": "This plugin allows you to create and use templates in Joplin.",


### PR DESCRIPTION
## Summary
- require Joplin v2.12.2 for plugin features by updating manifest
- document minimum Joplin version in README so users upgrade first

## Testing
- `npm test`
- `npm run lint` *(fails: unexpected any, unused vars, and quote style errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68a100b4f704832983632aeab30aaddf