### PR TITLE
fix timeline webview alignment and height

### DIFF
--- a/src/views/webview.css
+++ b/src/views/webview.css
@@ -1,5 +1,4 @@
 body {
-    text-align: center;
     font-size: 14px;
 }
 
@@ -33,6 +32,7 @@ input, select {
 }
 
 .variablesForm {
+    text-align: center;
     max-height: 80vh;
     overflow: scroll;
 }
@@ -41,7 +41,7 @@ input, select {
 .timeline-container {
     display: flex;
     flex-direction: column;
-    height: 100vh;
+    height: 100%;
 }
 
 .timeline-strip {


### PR DESCRIPTION
## Summary
- stop global centering in webview and keep forms centered
- use relative height for timeline container to avoid oversize panels

## Testing
- `npm test`
- `npm run lint` *(fails: 74 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a100b9863c832984b977ab9f94a4db